### PR TITLE
Update Pandas import to new format

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -5,7 +5,12 @@ from collections.abc import Iterable
 import numpy as np
 import yaml
 from scipy.stats.distributions import randint, rv_discrete, uniform
-from sklearn.utils import check_pandas_support, check_random_state
+from sklearn.utils import check_random_state
+try:
+    # Syntax from sklearn 1.5.0 onwards
+    from sklearn.utils._optional_dependencies import check_pandas_support
+except ImportError:
+    from sklearn.utils import check_pandas_support
 
 from .transformers import (
     CategoricalEncoder,


### PR DESCRIPTION
Great job taking over the project!

It fails to import with the latest sklearn (1.5.0) as they changed the import paths.

It would be great to have released a new version on pypi with this fix 